### PR TITLE
Fixes towards newer pyasn1 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # these need to be installed in the lib subdir
 M2Crypto==0.26.0
 fleece==0.13.0
-pyasn1==0.2.3
+pyasn1>=0.2.3

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
 
     install_requires=[
         # eg: 'aspectlib==1.1.1', 'six>=1.7',
-        "pyasn1==0.2.3",
+        "pyasn1>=0.2.3",
         "M2Crypto",
         "fleece",
         # verify-sigs is vendored in, so not listed here

--- a/src/fx_sig_verify/validate_moz_signature.py
+++ b/src/fx_sig_verify/validate_moz_signature.py
@@ -35,21 +35,6 @@ def debug(*args):
             print("{}: {}".format(now, msg))
 
 
-# EVIL EVIL -- Monkeypatch to extend accessor
-# This patch is part of the google code, and must be set before calling any of
-# the analysis routines. See the verify_sigs directory for license information.
-# TODO(user): This was submitted to pyasn1. Remove when we have it back.
-def F(self, idx):
-    if type(idx) is int:
-        return self.getComponentByPosition(idx)
-    else:
-        return self.getComponentByName(idx)
-from pyasn1.type import univ  # noqa: E402 pylint: disable-msg=C6204,C6203
-univ.SequenceAndSetBase.__getitem__ = F
-del F, univ
-# EVIL EVIL
-
-
 class MozSignedObject(object):
     """
     Retain the state and context of the object we're checking. This includes the

--- a/src/fx_sig_verify/verify_sigs/asn1/x509_time.py
+++ b/src/fx_sig_verify/verify_sigs/asn1/x509_time.py
@@ -37,17 +37,20 @@ class Time(univ.Choice):
       namedtype.NamedType('utcTime', useful.UTCTime()),
       namedtype.NamedType('generalTime', useful.GeneralizedTime()))
 
+  # pyasn1 0.3.1+ also supports .toDateTime() for ASN.1 time types
   def ToPythonEpochTime(self):
     """Takes a ASN.1 Time choice, and returns seconds since epoch in UTC."""
-    utc_time = self.getComponentByName('utcTime')
-    general_time = self.getComponentByName('generalTime')
-    if utc_time and general_time:
-      raise error.PyAsn1Error('Both elements of a choice are present.')
-    if general_time:
+    if not self.hasValue():
+        raise error.PyAsn1Error('Neither utcTime nor generalTime is present.')
+    name = self.getName()
+    component = self.getComponent()
+    if component is None or not component.hasValue():
+      raise error.PyAsn1Error('Neither utcTime nor generalTime is present.')
+    if name == 'generalTime':
       format_str = '%Y%m%d%H%M%SZ'
-      time_str = str(general_time)
+      time_str = str(component)
     else:
       format_str = '%y%m%d%H%M%SZ'
-      time_str = str(utc_time)
+      time_str = str(component)
     time_tpl = time.strptime(time_str, format_str)
     return calendar.timegm(time_tpl)

--- a/src/fx_sig_verify/verify_sigs/auth_data.py
+++ b/src/fx_sig_verify/verify_sigs/auth_data.py
@@ -327,7 +327,7 @@ class AuthData(object):
         params = self.spc_info['messageDigest']['digestAlgorithm']['parameters']
         self._ValidateEmptyParams(params)
 
-        if self.signed_data['crls']:
+        if self.signed_data['crls'] is not None and self.signed_data['crls'].hasValue():
             raise Asn1Error('Don\'t know what to do with CRL information.')
 
         # Work through signer_info pieces that are easily validated


### PR DESCRIPTION
This PR should make the fx-sig-verify tool working with pyasn1 0.2.3+.

Changes:
* Use `.hasValue()` (or `isValue`) when checking that pyasn1 object is initialized
* Reworked `ToPythonEpochTime` which had a side-effect on the certificate
* Removed very old hack obsoleted by contemporary pyasn1